### PR TITLE
fix: initialize arrays without fixed length to prevent holes

### DIFF
--- a/.changeset/green-crews-thank.md
+++ b/.changeset/green-crews-thank.md
@@ -1,0 +1,5 @@
+---
+"@folks-finance/algorand-sdk": patch
+---
+
+Fixed unstake transaction bug by initializing arrays with BigInt(0)s to prevent undefined elements during iteration.

--- a/src/xalgo/allocation-strategies/greedy.ts
+++ b/src/xalgo/allocation-strategies/greedy.ts
@@ -10,7 +10,7 @@ const greedyStakeAllocationStrategy = (
   amount: number | bigint,
 ): ProposerAllocations => {
   const { proposersBalances, maxProposerBalance } = consensusState;
-  const allocation = new Array<bigint>(proposersBalances.length);
+  const allocation = new Array<bigint>(proposersBalances.length).fill(BigInt(0));
 
   // sort in ascending order
   const indexed = proposersBalances.map((proposer, index) => ({ ...proposer, index }));
@@ -42,7 +42,7 @@ const greedyUnstakeAllocationStrategy = (
   amount: number | bigint,
 ): ProposerAllocations => {
   const { proposersBalances, minProposerBalance } = consensusState;
-  const allocation = new Array<bigint>(proposersBalances.length);
+  const allocation = new Array<bigint>(proposersBalances.length).fill(BigInt(0));
 
   // sort in descending order
   const indexed = proposersBalances.map((proposer, index) => ({ ...proposer, index }));


### PR DESCRIPTION
Changed array initialization to fill every slot with BigInt(0). This prevents empty slots (holes) that caused `for...of` loops in `prepare{Immediate|Delayed}StakeTransactions` and `prepareUnstakeTransactions` to process `undefined` elements, fixing the unstake transaction bug.