### PR TITLE
stake and deposit

### DIFF
--- a/.changeset/slimy-drinks-compete.md
+++ b/.changeset/slimy-drinks-compete.md
@@ -1,0 +1,5 @@
+---
+"@folks-finance/algorand-sdk": patch
+---
+
+stake and deposit util

--- a/src/xalgo/abi-contracts/index.ts
+++ b/src/xalgo/abi-contracts/index.ts
@@ -1,5 +1,7 @@
 import { ABIContract } from "algosdk";
 
+import stakeAndDepositABI from "./stake_and_deposit.json";
 import xAlgoABI from "./xalgo.json";
 
 export const xAlgoABIContract = new ABIContract(xAlgoABI);
+export const stakeAndDepositABIContract = new ABIContract(stakeAndDepositABI);

--- a/src/xalgo/abi-contracts/stake_and_deposit.json
+++ b/src/xalgo/abi-contracts/stake_and_deposit.json
@@ -1,0 +1,46 @@
+{
+  "name": "StakeAndDeposit",
+  "methods": [
+    {
+      "name": "stake_and_deposit",
+      "args": [
+        {
+          "type": "pay",
+          "name": "send_algo"
+        },
+        {
+          "type": "application",
+          "name": "consensus"
+        },
+        {
+          "type": "application",
+          "name": "pool"
+        },
+        {
+          "type": "application",
+          "name": "pool_manager"
+        },
+        {
+          "type": "asset",
+          "name": "x_algo"
+        },
+        {
+          "type": "asset",
+          "name": "f_x_algo"
+        },
+        {
+          "type": "account",
+          "name": "receiver"
+        },
+        {
+          "type": "uint64",
+          "name": "min_x_algo_received"
+        }
+      ],
+      "returns": {
+        "type": "void"
+      }
+    }
+  ],
+  "networks": {}
+}

--- a/src/xalgo/consensus.ts
+++ b/src/xalgo/consensus.ts
@@ -226,7 +226,7 @@ function prepareImmediateStakeTransactions(
 
 /**
  *
- * Returns a group transaction to stake ALGO and get xALGO immediately.
+ * Returns a group transaction to stake ALGO and deposit the xALGO received.
  *
  * @param consensusConfig - consensus application and xALGO config
  * @param consensusState - current state of the consensus application

--- a/src/xalgo/constants/mainnet-constants.ts
+++ b/src/xalgo/constants/mainnet-constants.ts
@@ -1,8 +1,9 @@
 import type { ConsensusConfig } from "../types";
 
 const MainnetConsensusConfig: ConsensusConfig = {
-  appId: 1134695678,
+  consensusAppId: 1134695678,
   xAlgoId: 1134696561,
+  stakeAndDepositAppId: 0,
 };
 
 export { MainnetConsensusConfig };

--- a/src/xalgo/constants/testnet-constants.ts
+++ b/src/xalgo/constants/testnet-constants.ts
@@ -1,8 +1,9 @@
 import type { ConsensusConfig } from "../types";
 
 const TestnetConsensusConfig: ConsensusConfig = {
-  appId: 730430673,
+  consensusAppId: 730430673,
   xAlgoId: 730430700,
+  stakeAndDepositAppId: 731190793,
 };
 
 export { TestnetConsensusConfig };

--- a/src/xalgo/types.ts
+++ b/src/xalgo/types.ts
@@ -1,6 +1,7 @@
 interface ConsensusConfig {
-  appId: number;
+  consensusAppId: number;
   xAlgoId: number;
+  stakeAndDepositAppId: number;
 }
 
 interface ConsensusState {


### PR DESCRIPTION
Added ability to stake xALGO and deposit the xALGO received. This is done through a utility smart contract.

Also updated the fees to overwrite the suggested params on the transfer calls.